### PR TITLE
Use const for option names

### DIFF
--- a/src/Controller/ArticleController.php
+++ b/src/Controller/ArticleController.php
@@ -22,7 +22,7 @@ class ArticleController extends AbstractController
     public function index(): Response
     {
         $data = await([
-            'LastArticles' => $this->builder->get(LastArticles::class, ['size' => 30]),
+            'LastArticles' => $this->builder->get(LastArticles::class, [LastArticles::SIZE => 30]),
         ]);
 
         dump($data);
@@ -34,9 +34,9 @@ class ArticleController extends AbstractController
     public function article(int $id): Response
     {
         $data = await([
-            'ArticleContent' => $this->builder->get(ArticleContent::class, ['id' => $id]),
-            'RelatedArticles' => $this->builder->get(RelatedArticles::class, ['id' => $id]),
-            'LastArticles' => $this->builder->get(LastArticles::class, ['size' => 3]),
+            'ArticleContent' => $this->builder->get(ArticleContent::class, [ArticleContent::ID => $id]),
+            'RelatedArticles' => $this->builder->get(RelatedArticles::class, [RelatedArticles::ID => $id]),
+            'LastArticles' => $this->builder->get(LastArticles::class, [LastArticles::SIZE => 3]),
         ]);
 
         dump($data);

--- a/src/Page/Block/ArticleContent.php
+++ b/src/Page/Block/ArticleContent.php
@@ -10,6 +10,8 @@ class ArticleContent implements Block
 {
     use WithApiClient;
 
+    public const ID = 'id';
+
     public function __invoke(array $options): array|View
     {
         $data = $this->apiClient->get('/v2/articles/'.$options['id']);
@@ -19,7 +21,7 @@ class ArticleContent implements Block
 
     public function configureOptions(OptionsResolver $resolver): void
     {
-        $resolver->define('id')
+        $resolver->define(self::ID)
             ->required()
             ->allowedTypes('int')
         ;

--- a/src/Page/Block/LastArticles.php
+++ b/src/Page/Block/LastArticles.php
@@ -10,6 +10,8 @@ class LastArticles implements Block
 {
     use WithApiClient;
 
+    public const SIZE = 'size';
+
     public function __invoke(array $options): array|View
     {
         $articles = $this->apiClient->get('/v2/articles?limit='.$options['size']);
@@ -19,7 +21,7 @@ class LastArticles implements Block
 
     public function configureOptions(OptionsResolver $resolver): void
     {
-        $resolver->define('size')
+        $resolver->define(self::SIZE)
             ->default(30)
             ->allowedTypes('int')
             ->allowedValues(fn (int $value): bool => $value > 1 && $value < 100)

--- a/src/Page/Block/RelatedArticles.php
+++ b/src/Page/Block/RelatedArticles.php
@@ -10,6 +10,8 @@ class RelatedArticles implements Block
 {
     use WithApiClient;
 
+    public const ID = 'id';
+
     public function __invoke(array $options): array|View
     {
         $data = $this->apiClient->get('/v2/articles/'.$options['id']);
@@ -23,7 +25,7 @@ class RelatedArticles implements Block
 
     public function configureOptions(OptionsResolver $resolver): void
     {
-        $resolver->define('id')
+        $resolver->define(self::ID)
             ->required()
             ->allowedTypes('int')
         ;


### PR DESCRIPTION
Goals:
- Less typo errors (even if OptionResolver can prevent this errors)
- Easier to locate when an option is used.

Using enum values as array key would be awesome, but that's [not supported](https://stitcher.io/blog/php-enums#enums-as-array-keys). 